### PR TITLE
molecule: migrate to molecule v3

### DIFF
--- a/ROLE_README.md
+++ b/ROLE_README.md
@@ -32,10 +32,6 @@ Use it in a playbook as follows:
     - cloudalchemy.<<APPLICATION>>
 ```
 
-### Demo site
-
-We provide demo site for full monitoring solution based on prometheus and grafana. Repository with code and links to running instances is [available on github](https://github.com/cloudalchemy/demo-site) and site is hosted on [DigitalOcean](https://digitalocean.com).
-
 ## Local Testing
 
 The preferred way of locally testing the role is to use Docker and [molecule](https://github.com/metacloud/molecule) (v2.x). You will have to install Docker on your system. See "Get started" for a Docker package suitable to for your system.

--- a/molecule/alternative/molecule.yml
+++ b/molecule/alternative/molecule.yml
@@ -3,8 +3,11 @@ dependency:
   name: galaxy
 driver:
   name: docker
-lint:
-  name: yamllint
+lint: |
+  set -e
+  yamllint .
+  ansible-lint
+  flake8
 platforms:
   - name: bionic
     image: quay.io/paulfantom/molecule-systemd:ubuntu-18.04
@@ -54,8 +57,6 @@ platforms:
       - python3
 provisioner:
   name: ansible
-  lint:
-    name: ansible-lint
   playbooks:
     create: ../default/create.yml
     prepare: prepare.yml
@@ -69,6 +70,3 @@ scenario:
   name: alternative
 verifier:
   name: testinfra
-  lint:
-    name: flake8
-    enabled: true

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -3,8 +3,11 @@ dependency:
   name: galaxy
 driver:
   name: docker
-lint:
-  name: yamllint
+lint: |
+  set -e
+  yamllint .
+  ansible-lint
+  flake8
 platforms:
   - name: bionic
     image: quay.io/paulfantom/molecule-systemd:ubuntu-18.04
@@ -54,8 +57,6 @@ platforms:
       - python3
 provisioner:
   name: ansible
-  lint:
-    name: ansible-lint
   playbooks:
     create: create.yml
     prepare: prepare.yml
@@ -69,6 +70,3 @@ scenario:
   name: default
 verifier:
   name: testinfra
-  lint:
-    name: flake8
-    enabled: true

--- a/molecule/latest/molecule.yml
+++ b/molecule/latest/molecule.yml
@@ -3,8 +3,11 @@ dependency:
   name: galaxy
 driver:
   name: docker
-lint:
-  name: yamllint
+lint: |
+  set -e
+  yamllint .
+  ansible-lint
+  flake8
 platforms:
   - name: buster
     image: quay.io/paulfantom/molecule-systemd:debian-10
@@ -22,8 +25,6 @@ platforms:
       - python3
 provisioner:
   name: ansible
-  lint:
-    name: ansible-lint
   playbooks:
     create: ../default/create.yml
     prepare: ../default/prepare.yml
@@ -37,6 +38,3 @@ scenario:
   name: latest
 verifier:
   name: testinfra
-  lint:
-    name: flake8
-    enabled: true

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-molecule>=2.15.0
+molecule>=3.0.0
 docker
 ansible-lint>=3.4.0
 testinfra>=1.7.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-molecule>=3.0.0
+molecule>=2.15.0,<3.0.0
 docker
 ansible-lint>=3.4.0
 testinfra>=1.7.0


### PR DESCRIPTION
Molecule v3 introduced some breaking changes in lint section causing problems which were observed in https://github.com/cloudalchemy/ansible-alertmanager/pull/116. More in https://molecule.readthedocs.io/en/latest/configuration.html#lint.