### PR TITLE
ROLE_README.md: Update demo site link

### DIFF
--- a/ROLE_README.md
+++ b/ROLE_README.md
@@ -34,7 +34,7 @@ Use it in a playbook as follows:
 
 ### Demo site
 
-We provide demo site for full monitoring solution based on prometheus and grafana. Repository with code and links to running instances is [available on github](https://github.com/cloudalchemy/demo-site) and site is hosted on [DigitalOcean](https://digitalocean.com).
+We provide demo site for full monitoring solution based on prometheus and grafana. Repository with code and links to running instances is [available on github](https://github.com/prometheus/demo-site) and site is hosted on [DigitalOcean](https://digitalocean.com).
 
 ## Local Testing
 


### PR DESCRIPTION
Use the new one available at https://github.com/prometheus/demo-site .

First fix of https://github.com/cloudalchemy/ansible-alertmanager/issues/132#issuecomment-650042311